### PR TITLE
Space research table crashes game in multiplayer

### DIFF
--- a/src/main/java/com/denfop/IUCore.java
+++ b/src/main/java/com/denfop/IUCore.java
@@ -1208,7 +1208,7 @@ public class IUCore {
     }
 
     private static boolean shouldRunTagBootstrap(TagsUpdatedEvent event) {
-        if (event.getUpdateCause() != TagsUpdatedEvent.UpdateCause.SERVER_DATA_LOAD) {
+        if (!event.shouldUpdateStaticData()) {
             return false;
         }
 

--- a/src/main/java/com/denfop/network/packet/PacketFixerRecipe.java
+++ b/src/main/java/com/denfop/network/packet/PacketFixerRecipe.java
@@ -43,6 +43,7 @@ public class PacketFixerRecipe implements IPacket {
         if (!IUCore.register) {
             IUCore.register = true;
             Iterable<Holder<Item>> tagOres = BuiltInRegistries.ITEM.getTagOrEmpty(ItemTags.create(new ResourceLocation("forge", "ores")));
+            SpaceInit.init();
             SpaceInit.jsonInit();
             new ScrapboxRecipeManager();
             if (mapRecipes.isEmpty() || mapRecipes1.isEmpty())


### PR DESCRIPTION
SpaceInit is not initialezed in multiplayer -> `SpaceNet.instance.getSystem()` is empty during `ScreenResearchTableSpace.renderMainMenu` -> `int nextIndex = (systemId + 1) % systems.size()` on line 823 throws division by zero exception

Additionally in `IUCore.shouldRunTagBootstrap` replaced the `SERVER_DATA_LOAD`-only check with Forge’s `shouldUpdateStaticData()`. That lets the dedicated client initialize when it receives tag sync (`CLIENT_PACKET_RECEIVED`), while still skipping duplicate bootstrap in integrated single player.