### PR TITLE
Remove Knockback from Radiation and fix damage tags not applying

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,9 +97,12 @@ dependencies {
     compileOnly "curse.maven:wireless-chargers-510656:5551798"
     compileOnly "curse.maven:flux-networks-248020:6089446"
     implementation "curse.maven:jei-238222:6577302"
+    compileOnly "curse.maven:tessellate-1660059:8757447"
     // runtime test
   //  runtimeOnly "curse.maven:jade-324717:5427817"
     runtimeOnly "curse.maven:crafttweaker-239197:6434161"
+    runtimeOnly "curse.maven:tessellate-1660059:8757447"
+    runtimeOnly "curse.maven:architectury-api-419699:8492726"
  //   runtimeOnly "mekanism:Mekanism:1.21.1-10.7.9.72"
    compileOnly fileTree('lib')
     runtimeOnly fileTree('lib')

--- a/src/generated/resources/data/industrialupgrade/recipe/industrialupgrade_672.json
+++ b/src/generated/resources/data/industrialupgrade/recipe/industrialupgrade_672.json
@@ -22,7 +22,7 @@
   ],
   "result": {
     "count": 1,
-    "id": "industrialupgrade:upgradekitmachine/upgradepanelkitmachine3"
+    "id": "industrialupgrade:upgradekitmachine/upgradekitmachine4"
   },
   "show_notification": false
 }

--- a/src/generated/resources/data/minecraft/tags/damage_type/bypasses_armor.json
+++ b/src/generated/resources/data/minecraft/tags/damage_type/bypasses_armor.json
@@ -1,19 +1,19 @@
 {
   "values": [
     {
-      "id": "#industrialupgrade:bee",
+      "id": "industrialupgrade:bee",
       "required": false
     },
     {
-      "id": "#industrialupgrade:current",
+      "id": "industrialupgrade:current",
       "required": false
     },
     {
-      "id": "#industrialupgrade:frostbite",
+      "id": "industrialupgrade:frostbite",
       "required": false
     },
     {
-      "id": "#industrialupgrade:poison_gas",
+      "id": "industrialupgrade:poison_gas",
       "required": false
     }
   ]

--- a/src/generated/resources/data/minecraft/tags/damage_type/is_fire.json
+++ b/src/generated/resources/data/minecraft/tags/damage_type/is_fire.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "#industrialupgrade:radiation",
+      "id": "industrialupgrade:radiation",
       "required": false
     }
   ]

--- a/src/main/java/com/denfop/blockentity/base/BlockEntityBase.java
+++ b/src/main/java/com/denfop/blockentity/base/BlockEntityBase.java
@@ -56,12 +56,14 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.energy.IEnergyStorage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.texboobcat.tessellate.api.TessellateApi;
 
 import java.io.IOException;
 import java.util.*;
@@ -429,34 +431,45 @@ public abstract class BlockEntityBase extends BlockEntity implements IMultiCellC
 
     public void loadBeforeFirstUpdate() {
         isLoaded = true;
-        try {
-            for (Direction direction : Direction.values())
-                if (!this.getLevel().isClientSide) {
-                    BlockPos neighborPos = pos.offset(direction.getNormal());
-                    BlockState neighbor = getLevel().getBlockState(neighborPos);
-                    if ((this instanceof EnergyTile || this.getComp(Energy.class) != null) && (neighbor.getBlock() instanceof EntityBlock && !(neighbor.getBlock() instanceof BlockTileEntity<?>))) {
-                        IEnergyStorage storage = level.getCapability(Capabilities.EnergyStorage.BLOCK, neighborPos, ModUtils.getFacingFromTwoPositions(this.pos, neighborPos));
-                        BlockEntity blockEntity = getLevel().getBlockEntity(neighborPos);
-                        if (storage != null && !blockEntity.isRemoved()) {
-                            EnergyTile energyTile = EnergyNetGlobal.instance.getTile(level, neighborPos);
-                            if (energyTile == EnergyNetGlobal.EMPTY) {
-                                EnergyForge energyForge = null;
-                                if (storage.canExtract() && storage.canReceive()) {
-                                    energyForge = new EnergyForgeSinkSource(blockEntity);
-                                } else if (storage.canReceive()) {
-                                    energyForge = new EnergyForgeSink(blockEntity);
-                                } else if (storage.canExtract()) {
-                                    energyForge = new EnergyForgeSource(blockEntity);
-                                }
-                                if (energyForge != null) {
-                                    NeoForge.EVENT_BUS.post(new EnergyTileLoadEvent(this.getWorld(), energyForge));
+        Runnable logic = () -> {
+            try {
+                for (Direction direction : Direction.values())
+                    if (!this.getLevel().isClientSide) {
+                        BlockPos neighborPos = pos.offset(direction.getNormal());
+                        BlockState neighbor = getLevel().getBlockState(neighborPos);
+                        if ((this instanceof EnergyTile || this.getComp(Energy.class) != null) && (neighbor.getBlock() instanceof EntityBlock && !(neighbor.getBlock() instanceof BlockTileEntity<?>))) {
+                            IEnergyStorage storage = level.getCapability(
+                                    Capabilities.EnergyStorage.BLOCK,
+                                    neighborPos,
+                                    ModUtils.getFacingFromTwoPositions(this.pos, neighborPos)
+                            );
+                            BlockEntity blockEntity = getLevel().getBlockEntity(neighborPos);
+                            if (storage != null && !blockEntity.isRemoved()) {
+                                EnergyTile energyTile = EnergyNetGlobal.instance.getTile(level, neighborPos);
+                                if (energyTile == EnergyNetGlobal.EMPTY) {
+                                    EnergyForge energyForge = null;
+                                    if (storage.canExtract() && storage.canReceive()) {
+                                        energyForge = new EnergyForgeSinkSource(blockEntity);
+                                    } else if (storage.canReceive()) {
+                                        energyForge = new EnergyForgeSink(blockEntity);
+                                    } else if (storage.canExtract()) {
+                                        energyForge = new EnergyForgeSource(blockEntity);
+                                    }
+                                    if (energyForge != null) {
+                                        NeoForge.EVENT_BUS.post(new EnergyTileLoadEvent(this.getWorld(), energyForge));
+                                    }
                                 }
                             }
                         }
                     }
-                }
-            this.rerender();
-        } catch (Exception e) {
+                this.rerender();
+            } catch (Exception e) {
+            }
+        };
+        if (ModList.get().isLoaded("tessellate")) {
+            TessellateApi.executeOnMainThread(logic);
+        }else {
+            logic.run();
         }
     }
 

--- a/src/main/java/com/denfop/datagen/DamageTypeTags.java
+++ b/src/main/java/com/denfop/datagen/DamageTypeTags.java
@@ -15,11 +15,11 @@ public class DamageTypeTags extends DamageTypeTagsProvider {
     }
 
     protected void addTags(HolderLookup.Provider pProvider) {
-        this.tag(net.minecraft.tags.DamageTypeTags.NO_KNOCKBACK).addOptionalTag(DamageTypes.radiationObject.location());
-         this.tag(net.minecraft.tags.DamageTypeTags.IS_FIRE).addOptionalTag(DamageTypes.radiationObject.location());
-        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.beeObject.location());
-        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.currentObject.location());
-        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.frostbiteObject.location());
-        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.poison_gasObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.NO_KNOCKBACK).addOptional(DamageTypes.radiationObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.IS_FIRE).addOptional(DamageTypes.radiationObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptional(DamageTypes.beeObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptional(DamageTypes.currentObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptional(DamageTypes.frostbiteObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptional(DamageTypes.poison_gasObject.location());
     }
 }

--- a/src/main/java/com/denfop/datagen/DamageTypeTags.java
+++ b/src/main/java/com/denfop/datagen/DamageTypeTags.java
@@ -15,6 +15,7 @@ public class DamageTypeTags extends DamageTypeTagsProvider {
     }
 
     protected void addTags(HolderLookup.Provider pProvider) {
+        this.tag(net.minecraft.tags.DamageTypeTags.NO_KNOCKBACK).addOptionalTag(DamageTypes.radiationObject.location());
          this.tag(net.minecraft.tags.DamageTypeTags.IS_FIRE).addOptionalTag(DamageTypes.radiationObject.location());
         this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.beeObject.location());
         this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.currentObject.location());

--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -63,6 +63,14 @@ description='''${mod_description}'''
     # Side this dependency is applied on - BOTH, CLIENT, or SERVER
     side="BOTH"
 
+[[dependencies.${mod_id}]]
+    modId="tessellate"
+    type="optional"
+    versionRange="[0.0.0,)"
+    ordering="NONE"
+    side="BOTH"
+
+
 # Here's another dependency
 [[dependencies.${mod_id}]]
     modId="minecraft"


### PR DESCRIPTION
Damage tags were being applied with addOptionalTag which treats resource locations as tags not damage types, addOptional correctly treats them as damage types. additionaly radiation effect damage flings the player all over the place, this is what I originally set out to fix.