### PR TITLE
Add tessellate compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,9 +97,12 @@ dependencies {
     compileOnly "curse.maven:wireless-chargers-510656:5551798"
     compileOnly "curse.maven:flux-networks-248020:6089446"
     implementation "curse.maven:jei-238222:6577302"
+    compileOnly "curse.maven:tessellate-1660059:8757447"
     // runtime test
   //  runtimeOnly "curse.maven:jade-324717:5427817"
     runtimeOnly "curse.maven:crafttweaker-239197:6434161"
+    runtimeOnly "curse.maven:tessellate-1660059:8757447"
+    runtimeOnly "curse.maven:architectury-api-419699:8492726"
  //   runtimeOnly "mekanism:Mekanism:1.21.1-10.7.9.72"
    compileOnly fileTree('lib')
     runtimeOnly fileTree('lib')

--- a/src/main/java/com/denfop/blockentity/base/BlockEntityBase.java
+++ b/src/main/java/com/denfop/blockentity/base/BlockEntityBase.java
@@ -56,12 +56,14 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.energy.IEnergyStorage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.texboobcat.tessellate.api.TessellateApi;
 
 import java.io.IOException;
 import java.util.*;
@@ -429,34 +431,45 @@ public abstract class BlockEntityBase extends BlockEntity implements IMultiCellC
 
     public void loadBeforeFirstUpdate() {
         isLoaded = true;
-        try {
-            for (Direction direction : Direction.values())
-                if (!this.getLevel().isClientSide) {
-                    BlockPos neighborPos = pos.offset(direction.getNormal());
-                    BlockState neighbor = getLevel().getBlockState(neighborPos);
-                    if ((this instanceof EnergyTile || this.getComp(Energy.class) != null) && (neighbor.getBlock() instanceof EntityBlock && !(neighbor.getBlock() instanceof BlockTileEntity<?>))) {
-                        IEnergyStorage storage = level.getCapability(Capabilities.EnergyStorage.BLOCK, neighborPos, ModUtils.getFacingFromTwoPositions(this.pos, neighborPos));
-                        BlockEntity blockEntity = getLevel().getBlockEntity(neighborPos);
-                        if (storage != null && !blockEntity.isRemoved()) {
-                            EnergyTile energyTile = EnergyNetGlobal.instance.getTile(level, neighborPos);
-                            if (energyTile == EnergyNetGlobal.EMPTY) {
-                                EnergyForge energyForge = null;
-                                if (storage.canExtract() && storage.canReceive()) {
-                                    energyForge = new EnergyForgeSinkSource(blockEntity);
-                                } else if (storage.canReceive()) {
-                                    energyForge = new EnergyForgeSink(blockEntity);
-                                } else if (storage.canExtract()) {
-                                    energyForge = new EnergyForgeSource(blockEntity);
-                                }
-                                if (energyForge != null) {
-                                    NeoForge.EVENT_BUS.post(new EnergyTileLoadEvent(this.getWorld(), energyForge));
+        Runnable logic = () -> {
+            try {
+                for (Direction direction : Direction.values())
+                    if (!this.getLevel().isClientSide) {
+                        BlockPos neighborPos = pos.offset(direction.getNormal());
+                        BlockState neighbor = getLevel().getBlockState(neighborPos);
+                        if ((this instanceof EnergyTile || this.getComp(Energy.class) != null) && (neighbor.getBlock() instanceof EntityBlock && !(neighbor.getBlock() instanceof BlockTileEntity<?>))) {
+                            IEnergyStorage storage = level.getCapability(
+                                    Capabilities.EnergyStorage.BLOCK,
+                                    neighborPos,
+                                    ModUtils.getFacingFromTwoPositions(this.pos, neighborPos)
+                            );
+                            BlockEntity blockEntity = getLevel().getBlockEntity(neighborPos);
+                            if (storage != null && !blockEntity.isRemoved()) {
+                                EnergyTile energyTile = EnergyNetGlobal.instance.getTile(level, neighborPos);
+                                if (energyTile == EnergyNetGlobal.EMPTY) {
+                                    EnergyForge energyForge = null;
+                                    if (storage.canExtract() && storage.canReceive()) {
+                                        energyForge = new EnergyForgeSinkSource(blockEntity);
+                                    } else if (storage.canReceive()) {
+                                        energyForge = new EnergyForgeSink(blockEntity);
+                                    } else if (storage.canExtract()) {
+                                        energyForge = new EnergyForgeSource(blockEntity);
+                                    }
+                                    if (energyForge != null) {
+                                        NeoForge.EVENT_BUS.post(new EnergyTileLoadEvent(this.getWorld(), energyForge));
+                                    }
                                 }
                             }
                         }
                     }
-                }
-            this.rerender();
-        } catch (Exception e) {
+                this.rerender();
+            } catch (Exception e) {
+            }
+        };
+        if (ModList.get().isLoaded("tessellate")) {
+            TessellateApi.executeOnMainThread(logic);
+        }else {
+            logic.run();
         }
     }
 

--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -63,6 +63,14 @@ description='''${mod_description}'''
     # Side this dependency is applied on - BOTH, CLIENT, or SERVER
     side="BOTH"
 
+[[dependencies.${mod_id}]]
+    modId="tessellate"
+    type="optional"
+    versionRange="[0.0.0,)"
+    ordering="NONE"
+    side="BOTH"
+
+
 # Here's another dependency
 [[dependencies.${mod_id}]]
     modId="minecraft"


### PR DESCRIPTION
Adds compatibility with Tessellate: https://www.curseforge.com/minecraft/mc-mods/tessellate. this fixes Industrial upgrade causing Tessellate to fall back to serial ticking with this compatibility report:

### Tessellate compatibility report

Tessellate fell back to serial execution while running `region-ticking`.

- Suspected mod: `industrialupgrade` `3.4.0.11`
- Minecraft: `1.21.1`
- Loader: `neoforge`
- Tessellate: `1.2.12`
- Reason code: `unloaded_chunk`
- Failure: `unknown`
- Suspected frame: `TRANSFORMER/industrialupgrade@3.4.0.11/com.denfop.blockentity.base.BlockEntityBase.loadBeforeFirstUpdate(BlockEntityBase.java:432)`
- Affected entity type: `unknown`
- Affected block entity type: `unknown`
- Event ID: `d9b8f069-7b59-4cf5-88fb-68d0988ec6a2`

Reason: falling back to serial region ticking for this session: a region worker needed chunk [-17, -13] at status minecraft:full, which was not loaded. Fetching it would have required the main thread.

### Compatibility guidance

Prefer moving only the unsafe operation: use `TessellateApi.executeOnRegion(level, pos, work)` for world access owned by another region, or `TessellateApi.executeOnMainThread(work)` for main-thread-only state. If the whole type is unsafe, register only the affected type during mod initialization with `TessellateApi.registerMainThreadEntity(type)` or `TessellateApi.registerMainThreadBlockEntity(type)`.

- GitHub compatibility guide: https://github.com/ColinVaughn/Tessellate#compatibility
- Tessellate Discord: https://discord.gg/dPY6zmHtr5

_The suspected mod was detected automatically from the failing stack frame._