### PR TITLE
Remove Knockback from Radiation and fix damage tags not applying

### DIFF
--- a/src/generated/resources/data/industrialupgrade/recipe/industrialupgrade_672.json
+++ b/src/generated/resources/data/industrialupgrade/recipe/industrialupgrade_672.json
@@ -22,7 +22,7 @@
   ],
   "result": {
     "count": 1,
-    "id": "industrialupgrade:upgradekitmachine/upgradepanelkitmachine3"
+    "id": "industrialupgrade:upgradekitmachine/upgradekitmachine4"
   },
   "show_notification": false
 }

--- a/src/generated/resources/data/minecraft/tags/damage_type/bypasses_armor.json
+++ b/src/generated/resources/data/minecraft/tags/damage_type/bypasses_armor.json
@@ -1,19 +1,19 @@
 {
   "values": [
     {
-      "id": "#industrialupgrade:bee",
+      "id": "industrialupgrade:bee",
       "required": false
     },
     {
-      "id": "#industrialupgrade:current",
+      "id": "industrialupgrade:current",
       "required": false
     },
     {
-      "id": "#industrialupgrade:frostbite",
+      "id": "industrialupgrade:frostbite",
       "required": false
     },
     {
-      "id": "#industrialupgrade:poison_gas",
+      "id": "industrialupgrade:poison_gas",
       "required": false
     }
   ]

--- a/src/generated/resources/data/minecraft/tags/damage_type/is_fire.json
+++ b/src/generated/resources/data/minecraft/tags/damage_type/is_fire.json
@@ -1,7 +1,7 @@
 {
   "values": [
     {
-      "id": "#industrialupgrade:radiation",
+      "id": "industrialupgrade:radiation",
       "required": false
     }
   ]

--- a/src/main/java/com/denfop/datagen/DamageTypeTags.java
+++ b/src/main/java/com/denfop/datagen/DamageTypeTags.java
@@ -15,11 +15,11 @@ public class DamageTypeTags extends DamageTypeTagsProvider {
     }
 
     protected void addTags(HolderLookup.Provider pProvider) {
-        this.tag(net.minecraft.tags.DamageTypeTags.NO_KNOCKBACK).addOptionalTag(DamageTypes.radiationObject.location());
-         this.tag(net.minecraft.tags.DamageTypeTags.IS_FIRE).addOptionalTag(DamageTypes.radiationObject.location());
-        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.beeObject.location());
-        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.currentObject.location());
-        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.frostbiteObject.location());
-        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.poison_gasObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.NO_KNOCKBACK).addOptional(DamageTypes.radiationObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.IS_FIRE).addOptional(DamageTypes.radiationObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptional(DamageTypes.beeObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptional(DamageTypes.currentObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptional(DamageTypes.frostbiteObject.location());
+        this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptional(DamageTypes.poison_gasObject.location());
     }
 }

--- a/src/main/java/com/denfop/datagen/DamageTypeTags.java
+++ b/src/main/java/com/denfop/datagen/DamageTypeTags.java
@@ -15,6 +15,7 @@ public class DamageTypeTags extends DamageTypeTagsProvider {
     }
 
     protected void addTags(HolderLookup.Provider pProvider) {
+        this.tag(net.minecraft.tags.DamageTypeTags.NO_KNOCKBACK).addOptionalTag(DamageTypes.radiationObject.location());
          this.tag(net.minecraft.tags.DamageTypeTags.IS_FIRE).addOptionalTag(DamageTypes.radiationObject.location());
         this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.beeObject.location());
         this.tag(net.minecraft.tags.DamageTypeTags.BYPASSES_ARMOR).addOptionalTag(DamageTypes.currentObject.location());


### PR DESCRIPTION
Damage tags were being applied with addOptionalTag which treats resource locations as tags not damage types, addOptional correctly treats them as damage types. additionaly radiation effect damage flings the player all over the place, this is what I originally set out to fix.

I apologize for the duplicate pr, but I figured It would be better to keep this and tessellate compatibility seperate