### PR TITLE
Fix Deadlock with C2ME on unloading chunk with multiblock

### DIFF
--- a/src/main/java/com/denfop/blockentity/base/BlockEntityBase.java
+++ b/src/main/java/com/denfop/blockentity/base/BlockEntityBase.java
@@ -35,6 +35,7 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
@@ -973,7 +974,10 @@ public abstract class BlockEntityBase extends BlockEntity implements IMultiCellC
         }
 
         if (!lifecycleUnloading && level != null && !level.isClientSide && this.needCollision()) {
-            MultiCellCollisionManager.removeAll(level, this.getBlockPos());
+            MinecraftServer server = level.getServer();
+            server.tell(new TickTask(server.getTickCount(), () -> {
+                MultiCellCollisionManager.removeAll(level, this.getBlockPos());
+            }));
         }
     }
 

--- a/src/main/java/com/denfop/blockentity/mechanism/multiblocks/base/BlockEntityMultiBlockBase.java
+++ b/src/main/java/com/denfop/blockentity/mechanism/multiblocks/base/BlockEntityMultiBlockBase.java
@@ -25,6 +25,8 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.TickTask;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemDisplayContext;
@@ -580,16 +582,25 @@ public abstract class BlockEntityMultiBlockBase extends BlockEntityInventory imp
             GlobalRenderManager.removeRender(this.getWorld(), pos);
         }
         if (this.isFull()) {
-            if (this.multiBlockStructure != null) {
-                List<BlockPos> blockPosList = this.multiBlockStructure.getPoses(this.getFacing(), this.getBlockPos());
-                for (BlockPos pos1 : blockPosList) {
-                    BlockEntity tileentity = this.getLevel().getBlockEntity(pos1);
-                    if (tileentity instanceof BlockEntityMultiBlockElement) {
-                        BlockEntityMultiBlockElement te = (BlockEntityMultiBlockElement) tileentity;
-                        te.setMainMultiElement(null);
+            Runnable logic = () -> {
+                if (this.multiBlockStructure != null) {
+                    List<BlockPos> blockPosList = this.multiBlockStructure.getPoses(this.getFacing(), this.getBlockPos());
+                    for (BlockPos pos1 : blockPosList) {
+                        BlockEntity tileentity = this.getLevel().getBlockEntity(pos1);
+                        if (tileentity instanceof BlockEntityMultiBlockElement) {
+                            BlockEntityMultiBlockElement te = (BlockEntityMultiBlockElement) tileentity;
+                            te.setMainMultiElement(null);
+                        }
                     }
                 }
+            };
+            if (level.getServer() != null) {
+                MinecraftServer server = level.getServer();
+                server.tell(new TickTask(server.getTickCount(), logic));
+            } else {
+                logic.run();
             }
+
         }
         super.onUnloaded();
     }


### PR DESCRIPTION
Unloading a chunk with c2me installed causes level.getBlockEntity() to deadlock due to c2me threaded chunk unloading.